### PR TITLE
url recognition

### DIFF
--- a/src/reviewtools/bugz.py
+++ b/src/reviewtools/bugz.py
@@ -88,9 +88,9 @@ class ReviewBug(Helpers):
 [$-_@.&+~]|[!*\(\),]|(?:%[0-9a-fA-F~\.][0-9a-fA-F]))+', body)
                 if urls:
                     for url in urls:
-                        if url.endswith(".spec"):
+                        if ".spec" in url:
                             self.spec_url = url
-                        elif url.endswith(".src.rpm"):
+                        elif ".src.rpm" in url:
                             self.srpm_url = url
         if not self.spec_url:
             self.log.info('not spec file URL found in bug #%s' % self.bug_num)


### PR DESCRIPTION
I made it a little bit more fuzzy. i.e. the old one doesn't recognize urls like: https://github.com/Ignotus/wicd-kde-fedora/blob/cc0799b8e90a4d27a77b5e3979e376d859687c56/wicd-kde-0.2.3-2.fc15.src.rpm?raw=true

Look at the end "?raw=true"
