### PR TITLE
Fix regex for gem install matching

### DIFF
--- a/plugins/ruby.py
+++ b/plugins/ruby.py
@@ -398,7 +398,7 @@ class GemCheckGemInstallMacro(GemCheckBase):
         self.type = 'SHOULD'
 
     def run_on_applicable(self):
-        gem_install_re = re.compile(r'^.*gem\s+install', re.I)
+        gem_install_re = re.compile(r'^[^#]*gem\s+install', re.I)
         self.set_passed(
             self.FAIL if self.spec.find_re(gem_install_re) else self.PASS)
 


### PR DESCRIPTION
See #23 

The current regex matches the string 'gem install' when present in a
comment, which is not the desired behavior. This commit keeps the
original idea of matching the command presence, matching it
whenever not in a comment.
